### PR TITLE
Fix typo in user manual post

### DIFF
--- a/_posts/2023-10-05-user-manual.md
+++ b/_posts/2023-10-05-user-manual.md
@@ -51,7 +51,7 @@ Let's all be a little more transparent. Below is my manual.
 
 Consider the channel you use to message me, the below is a guide to how I treat each with my personal SLAs:
 
-- **WhatApp**: Urgent P0 level needs [ _Response time: ~minutes_ ]
+- **WhatsApp**: Urgent P0 level needs [ _Response time: ~minutes_ ]
 - **Slack**: Important short-form communication [ _Response time: ~hours_ ]
 - **Email**: Non urgent long-form communication [ _Response time: ~weeks_ ]
 


### PR DESCRIPTION
## Summary
- fix the WhatsApp spelling in the October 2023 user manual post

## Testing
- `grep -n WhatsApp _posts/2023-10-05-user-manual.md`

------
https://chatgpt.com/codex/tasks/task_e_687e243e807483338fa11737d3044ab2