### PR TITLE
Add setup script for bundler install

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 Personal blog space, built using [Jekyll](https://jekyllrb.com) deployed using GitHub Pages
 
+## Setup
+
+Run `./setup.sh` to install Bundler (if needed) and install the project gems
+into `vendor/bundle`.
+
 ## Running
 
 `bundle exec jekyll serve`

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+
+# Install Bundler if it's not already available
+if ! command -v bundle >/dev/null 2>&1; then
+  gem install bundler
+fi
+
+# Configure Bundler to install gems locally
+bundle config set --local path 'vendor/bundle'
+
+# Install project dependencies
+bundle install
+


### PR DESCRIPTION
## Summary
- add `setup.sh` for bundler setup and install
- mention the setup script in the README

## Testing
- `./setup.sh` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687e25cd72f48333a259c0cc8a422205