### PR TITLE
Add dark mode support

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -29,6 +29,7 @@
     <link rel="mask-icon" href="/assets/manifest/safari-pinned-tab.svg" color="#5bbad5">
     <meta name="msapplication-TileColor" content="#00aba9">
     <meta name="theme-color" content="#ffffff">
+    <meta name="color-scheme" content="light dark">
     <title>Ruan Odendaal - {{ page.title }}</title>
     {% if jekyll.environment == 'production' %}
       {% include analytics.html %}

--- a/_sass/dark-mode.scss
+++ b/_sass/dark-mode.scss
@@ -1,0 +1,34 @@
+@use "sass:map";
+@use "variables" as vars;
+
+@media (prefers-color-scheme: dark) {
+  html {
+    background-color: #121212;
+    color: #e0e0e0;
+  }
+
+  body {
+    background-color: #121212;
+  }
+
+  .subtitle {
+    color: #e0e0e0;
+  }
+
+  .post-list__item {
+    border-bottom: 1px solid #333;
+  }
+
+  blockquote p {
+    border-left-color: #bb86fc;
+  }
+
+  pre {
+    background-color: #1e1e1e !important;
+    border-left-color: #bb86fc !important;
+  }
+
+  .tags li {
+    background: #333;
+  }
+}

--- a/_sass/dark-mode.scss
+++ b/_sass/dark-mode.scss
@@ -28,6 +28,11 @@
     border-left-color: #bb86fc !important;
   }
 
+  .post a,
+  p .header-links {
+    color: #9eaeef;
+  }
+
   .tags li {
     background: #333;
   }

--- a/_sass/dark-mode.scss
+++ b/_sass/dark-mode.scss
@@ -36,4 +36,8 @@
   .tags li {
     background: #333;
   }
+
+  nav svg path:last-of-type {
+    fill: #e0e0e0;
+  }
 }

--- a/assets/css/index.scss
+++ b/assets/css/index.scss
@@ -11,3 +11,4 @@
 @use "posts";
 @use "code";
 @use "tables";
+@use "dark-mode";

--- a/assets/js/code-blocks.js
+++ b/assets/js/code-blocks.js
@@ -1,12 +1,13 @@
 // Enhancing code blocks with copy functionality and language detection
 
 document.addEventListener('DOMContentLoaded', function() {
+  const isDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
   // Fix for GitHub Pages styling conflicts
-  document.querySelectorAll('pre').forEach(function(pre) {
-    pre.style.backgroundColor = '#f8f9fa';
-    pre.style.borderLeft = '4px solid #4e42ff';
-    pre.style.position = 'relative';
-    pre.style.overflow = 'auto';
+  document.querySelectorAll("pre").forEach(function(pre) {
+    pre.style.backgroundColor = isDark ? "#1e1e1e" : "#f8f9fa";
+    pre.style.borderLeft = isDark ? "4px solid #bb86fc" : "4px solid #4e42ff";
+    pre.style.position = "relative";
+    pre.style.overflow = "auto";
   });
   // Find all pre > code blocks
   const codeBlocks = document.querySelectorAll('pre > code');
@@ -69,18 +70,18 @@ document.addEventListener('DOMContentLoaded', function() {
     table.style.width = '100%';
     
     // Style all table headers
-    table.querySelectorAll('th').forEach(function(th) {
-      th.style.backgroundColor = '#f8f9fa';
-      th.style.borderBottom = '2px solid #4e42ff';
-      th.style.padding = '12px 15px';
-      th.style.textAlign = 'left';
-    });
+      table.querySelectorAll("th").forEach(function(th) {
+        th.style.backgroundColor = isDark ? "#1e1e1e" : "#f8f9fa";
+        th.style.borderBottom = isDark ? "2px solid #bb86fc" : "2px solid #4e42ff";
+        th.style.padding = "12px 15px";
+        th.style.textAlign = "left";
+      });
     
     // Style all table cells
-    table.querySelectorAll('td').forEach(function(td) {
-      td.style.borderBottom = '1px solid #e6e6e6';
-      td.style.padding = '12px 15px';
-    });
+      table.querySelectorAll("td").forEach(function(td) {
+        td.style.borderBottom = isDark ? "1px solid #444" : "1px solid #e6e6e6";
+        td.style.padding = "12px 15px";
+      });
     
     // Look for specific format in the user manual
     if (table.querySelector('td:first-child') && 


### PR DESCRIPTION
## Summary
- support dark mode with CSS `prefers-color-scheme`
- import new dark mode stylesheet
- tweak pre and table JS styling when dark mode is active
- advertise light/dark color scheme in the document head

## Testing
- `./setup.sh`
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_687e2a7aa8cc83339bd71928798af092