### PR TITLE
Fix dark mode table zebra styling

### DIFF
--- a/_sass/dark-mode.scss
+++ b/_sass/dark-mode.scss
@@ -54,6 +54,10 @@
     background-color: #2a2a2a;
   }
 
+  tr:hover td {
+    color: #e0e0e0 !important;
+  }
+
   th {
     background-color: #1e1e1e !important;
     border-bottom-color: #bb86fc !important;
@@ -61,5 +65,6 @@
 
   td {
     border-bottom-color: #444 !important;
+    color: #e0e0e0 !important;
   }
 }

--- a/_sass/dark-mode.scss
+++ b/_sass/dark-mode.scss
@@ -40,4 +40,26 @@
   nav svg path:last-of-type {
     fill: #e0e0e0;
   }
+
+  // Improve table readability in dark mode
+  table {
+    color: #e0e0e0;
+  }
+
+  tr:nth-child(even) {
+    background-color: #1e1e1e;
+  }
+
+  tr:hover {
+    background-color: #2a2a2a;
+  }
+
+  th {
+    background-color: #1e1e1e !important;
+    border-bottom-color: #bb86fc !important;
+  }
+
+  td {
+    border-bottom-color: #444 !important;
+  }
 }


### PR DESCRIPTION
## Summary
- adjust dark-mode table styling for better visibility

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_687e413c24888333b574ff4cd13c2e70